### PR TITLE
Add missing Tailwind config requirement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ const config = {
   content: [
     "./src/**/*.{html,js,svelte,ts}",
     "./node_modules/flowbite-svelte/**/*.{html,js,svelte,ts}",
+    "./node_modules/flowbite-svelte-blocks/**/*.{html,js,svelte,ts}",
   ],
 
   theme: {


### PR DESCRIPTION
## 📑 Description

If the `flowbite-svelte-blocks` styling is not included as TailwindCSS content, some classes may be missed. In turn, this means that blocks will not be rendered as they were meant to.

I've fixed this by letting others know that this must be added in the README.

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed